### PR TITLE
update unexpected to 5 beta 9

### DIFF
--- a/lib/memoizeAsync.js
+++ b/lib/memoizeAsync.js
@@ -74,7 +74,7 @@
             } else {
                 waitingCallbacksByStringifiedArguments[stringifiedArguments] = [cb];
                 lambda.apply(options.context || that, args.concat(function () { // ...
-                    var resultCallbackParams = arguments,
+                    var resultCallbackParams = Array.prototype.slice.call(arguments),
                         waitingCallbacks = waitingCallbacksByStringifiedArguments[stringifiedArguments];
                     if (!resultCallbackParams[0] || options.errors) {
                         cache.set(cacheKeyPrefix + stringifiedArguments, resultCallbackParams);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "mocha": "=1.18.2",
-    "unexpected": "=3.1.5"
+    "unexpected": "5.0.0-beta9"
   },
   "scripts": {
     "prepublish": "mocha",


### PR DESCRIPTION
Upgrading unexpected made a test fail where an array was expected
where an arguments-array was returned.

Changing it to actually set an array instead of changing the test
seemed to be the proper fix for this.
